### PR TITLE
Frontmatter fixes for title and image fields

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path")
 const luxon = require("luxon");
 const xml2js = require("xml2js");
 
@@ -25,7 +26,7 @@ async function parseFilePromise(config) {
     images.push(...collectScrapedImages(data, postTypes));
   }
 
-  mergeImagesIntoPosts(images, posts);
+  mergeImagesIntoPosts(images, posts, config);
 
   return posts;
 }
@@ -218,7 +219,7 @@ function collectScrapedImages(data, postTypes) {
  * 5. transfer images folder to content/assets ? (images/... --> assets/images/...)
  */
 
-function mergeImagesIntoPosts(images, posts) {
+function mergeImagesIntoPosts(images, posts, config) {
   images.forEach((image) => {
     posts.forEach((post) => {
       let shouldAttach = false;
@@ -231,7 +232,7 @@ function mergeImagesIntoPosts(images, posts) {
       // this image was set as the featured image for this post
       if (image.id === post.meta.coverImageId) {
         shouldAttach = true;
-        post.frontmatter.image = shared.getFilenameFromUrl(image.url);
+        post.frontmatter.image = path.join(config.assets, "images", shared.getFilenameFromUrl(image.url));
       }
 
       if (shouldAttach && !post.meta.imageUrls.includes(image.url)) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -120,11 +120,12 @@ function getPostCoverImageId(post) {
 }
 
 function getPostTitle(post) {
-  //console.log(post)
-  //if title has Html in it, return the post name instead
+  // if title has Html in it, return the post name instead
   const re = /^</;
   if (re.test(post.title[0])) {
-    return post.post_name[0];
+    const title = post.post_name[0].replace("-", " ")
+    // capitalize each word
+    return title.replace(/(^\w|\s\w)(\S*)/g, (_,m1,m2) => m1.toUpperCase()+m2.toLowerCase());
   } else {
     return post.title[0];
   }
@@ -230,7 +231,7 @@ function mergeImagesIntoPosts(images, posts) {
       // this image was set as the featured image for this post
       if (image.id === post.meta.coverImageId) {
         shouldAttach = true;
-        post.frontmatter.coverImage = shared.getFilenameFromUrl(image.url);
+        post.frontmatter.image = shared.getFilenameFromUrl(image.url);
       }
 
       if (shouldAttach && !post.meta.imageUrls.includes(image.url)) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -80,7 +80,7 @@ function collectPosts(data, postTypes, config) {
         },
         frontmatter: {
           title: getPostTitle(post),
-          date: getPostDate(post),
+          created: getPostDate(post),
           categories: getCategories(post),
           tags: getTags(post),
         },

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -23,6 +23,7 @@ const destDir = 'tests/output'
 const defaultConfig = {
   input: './lifeitself.xml',
   output: destDir,
+  assets: 'assets',
   yearFolders: false,
   monthFolders: false,
   postFolders: false,
@@ -83,4 +84,5 @@ test("contains frontmatter image field", async () => {
   const post = allDocs.find(f => f.meta.slug === "can-digital-businesses-thrive-and-be-mindful")
 
   expect(post.frontmatter.image).toBeDefined()
+  expect(post.frontmatter.image).toBe("assets/images/Blog-Feature-Images-14.png")
 })

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -38,7 +38,7 @@ const testPostSlug = path.join(destDir, "post", "non-attachment-to-views-by-jona
 const testFrontmatter =
 `---
 title: "Jonathan Ekstrom: Non Attachment to Views"
-date: 2016-10-06
+created: 2016-10-06
 categories: 
   - book-notes
 tags: 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -32,7 +32,7 @@ const defaultConfig = {
   includeOtherTypes: true
 }
 
-const testPost = "tests/output/post/non-attachment-to-views-by-jonathan-ekstrom.md"
+const testPostSlug = path.join(destDir, "post", "non-attachment-to-views-by-jonathan-ekstrom.md")
 
 const testFrontmatter =
 `---
@@ -47,13 +47,12 @@ tags:
 
 test("creates an output directory with markdown files", async () => {
   const allDocs = await parser.parseFilePromise(defaultConfig)
-
-  const pages = allDocs.filter(p => ["page"].includes(p.meta.type)).slice(0,2)
-  const posts = allDocs.filter(p => ["post"].includes(p.meta.type)).slice(0,2)
+  const pages = allDocs.filter(p => ["page"].includes(p.meta.type)).slice(0,1)
+  const posts = allDocs.filter(p => ["post"].includes(p.meta.type)).slice(0,1)
 
   const slicedPosts = [ ...pages, ...posts ]
 
-  fs.rmSync(destDir, { recursive: true, force: true });
+  if (fs.existsSync(destDir)) fs.rmSync(destDir, { recursive: true, force: true });
   await writer.writeFilesPromise(slicedPosts, defaultConfig);
 
   expect(fs.existsSync(destDir)).toBe(true)
@@ -61,9 +60,27 @@ test("creates an output directory with markdown files", async () => {
 
 test("outputs the frontmatter in markdown", () => {
   getFilesRecursively(destDir)
-  const file = files.find(f => f === testPost)
+  const file = files.find(f => f === testPostSlug)
   const fileContent = fs.readFileSync(file, "utf8")
   const fileFrontmatter = fileContent.substring(0, fileContent.lastIndexOf("---") + 3)
 
   expect(fileFrontmatter).toMatch(testFrontmatter)
+})
+
+test("parses the frontmatter title correctly", async () => {
+  const allDocs = await parser.parseFilePromise(defaultConfig)
+  const page = allDocs.find(f => f.meta.slug === "imaginary-society")
+
+  expect(page.frontmatter.title).toEqual("Imaginary Society")
+})
+
+test("contains frontmatter image field", async () => {
+  const config = {
+    ...defaultConfig,
+    saveAttachedImages: true
+  }
+  const allDocs = await parser.parseFilePromise(config)
+  const post = allDocs.find(f => f.meta.slug === "can-digital-businesses-thrive-and-be-mindful")
+
+  expect(post.frontmatter.image).toBeDefined()
 })


### PR DESCRIPTION
### Summary

This PR adds changes to the title, date & image frontmatter fields.

### Changes
* Fix parsing of titles from slug `example-title --> Example Title`
* Rename `coverImage` to `image`
* Fix `image` paths in frontmatter
* Rename `date` to `created`
* Add test for titles parsing

### Example screenshot
<img width="319" alt="Screen Shot 2022-11-30 at 2 11 05 AM" src="https://user-images.githubusercontent.com/42637597/204659628-26245343-523c-4dd2-871d-709a5eb7886d.png">
