### PR TITLE
Extract page files to root output folder

### DIFF
--- a/src/writer.js
+++ b/src/writer.js
@@ -46,7 +46,9 @@ async function writeMarkdownFilesPromise(posts, config ) {
 	let skipCount = 0;
 	let delay = 0;
 	const payloads = posts.flatMap(post => {
-		const destinationPath = getPostPath(post, config);
+		const destinationPath = post.meta.type === "page"
+			? path.join(config.output, post.meta.slug + ".md")
+			: getPostPath(post, config);
 		if (checkFile(destinationPath)) {
 			// already exists, don't need to save again
 			skipCount++;


### PR DESCRIPTION
### Summary

This PR modifies the extraction of the page files from wordpress to the root of the output directory. All other folders remain intact. (eg. post, etc..)

### Changes

* Change destination path of page folder to `config.output` directory